### PR TITLE
defaultdict for matches, format output, summary option, simpler Python2 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ optional arguments:
   -h, --help          show this help message and exit
   -p path [path ...]  Path to scan
   -d distance         Maximum distance between each character
+  --debug             Debug output
   --defaultpaths      Scan a set of default paths that should contain relevant log files.
   --quick             Skip log lines that don't contain a 2021 or 2022 time stamp
   --summary           Show summary only
-  --debug             Debug output
 ```
 
 ## Special Flags
@@ -70,9 +70,9 @@ No further or special Python modules are required. It should run on any system t
 
 There are different ways how you can help.
 
-A. Test it against the payloads that you find in-the-wild and let me know if we miss something
-B. Help me find and fix bugs
-C. Test if the scripts runs with Python 2; if not, we can add a slightly modified version to the repo
+1. Test it against the payloads that you find in the wild and let me know if we miss something.
+2. Help me find and fix bugs.
+3. Test if the scripts runs with Python 2; if not, we can add a slightly modified version to the repo.
 
 ## Contact
 

--- a/README.md
+++ b/README.md
@@ -34,20 +34,25 @@ optional arguments:
   -h, --help          show this help message and exit
   -p path [path ...]  Path to scan
   -d distance         Maximum distance between each character
-  --quick             Skip log lines that don't contain a 2021 or 2022 time stamp
   --defaultpaths      Scan a set of default paths that should contain relevant log files.
+  --quick             Skip log lines that don't contain a 2021 or 2022 time stamp
+  --summary           Show summary only
   --debug             Debug output
 ```
 
 ## Special Flags
 
+### --defaultpaths
+
+Check a list of default log paths used by different software products. 
+
 ### --quick 
 
 Only checks log lines that contain a `2021` or `2022` to exclude all scanning of older log entries. We assume that the vulnerability wasn't exploited in 2019 and earlier. 
 
-### --defaultpaths
+### --summary
 
-Check a list of default log paths used by different software products. 
+Prints a summary of matches, with only the filename and line number.
 
 ## Requirements 
 

--- a/log4shell-detector.py
+++ b/log4shell-detector.py
@@ -244,4 +244,4 @@ if __name__ == '__main__':
     duration = date_scan_end - date_scan_start
     mins, secs = divmod(duration.total_seconds(), 60)
     hours, mins = divmod(mins, 60)
-    print("[.] Scan took the followwing time to complete DURATION: %d hours %d minutes %d seconds" % (hours, mins, secs))
+    print("[.] Scan took the following time to complete DURATION: %d hours %d minutes %d seconds" % (hours, mins, secs))

--- a/log4shell-detector.py
+++ b/log4shell-detector.py
@@ -160,7 +160,7 @@ class Log4ShellDetector(object):
             if self.summary:
                 for match in matches:
                     for line_number in matches[match]:
-                        print('[!] FILE: %s LINE_NUMBER: %d' % (match, line_number))
+                        print('[!] FILE: %s LINE_NUMBER: %d STRING: %s' % (match, line_number, matches[match][line_number][1]))
         else:
             print("\n[+] No files with exploitation attempts detected in path PATH: %s" % path)
         return number_of_detections
@@ -215,7 +215,7 @@ if __name__ == '__main__':
             if not os.path.isfile(f):
                 print("[E] File %s doesn't exist" % f)
                 continue
-            print("[+] Scanning FILE: %s ..." % f)
+            print("[.] Scanning FILE: %s ..." % f)
             matches = defaultdict(lambda: defaultdict())
             matches_found = l4sd.scan_file(f)
             if len(matches_found) > 0:
@@ -237,7 +237,7 @@ if __name__ == '__main__':
                 if not args.defaultpaths:
                     print("[E] Path %s doesn't exist" % path)
                 continue
-            print("[+] Scanning FOLDER: %s ..." % path)
+            print("[.] Scanning FOLDER: %s ..." % path)
             detections = l4sd.scan_path(path)
             all_detections += detections
 

--- a/log4shell-detector.py
+++ b/log4shell-detector.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 __author__ = "Florian Roth"
-__version__ = "0.7"
+__version__ = "0.8"
 __date__ = "2021-12-11"
 
 import argparse
@@ -147,9 +147,8 @@ class Log4ShellDetector(object):
                         
         if not self.summary:
             for match in matches:
-                print('\nFILE: %s' % match)
                 for line_number in matches[match]:
-                    print('\n  LINE_NUMBER: %s\n    DEOBFUSCATED_STRING: %s' % (line_number, matches[match][line_number]))
+                    print('[!] FILE: %s LINE_NUMBER: %s DEOBFUSCATED_STRING: %s LINE: %s' % (match, line_number, matches[match][line_number][1], matches[match][line_number][0]))
         # Result
         number_of_detections = 0
         number_of_files_with_detections = len(matches.keys())
@@ -157,12 +156,11 @@ class Log4ShellDetector(object):
             number_of_detections += len(matches[file_path].keys())
        
         if number_of_detections > 0:
-            print("\n[!] %d files with exploitation attempts detected in PATH: %s" % (number_of_files_with_detections, path))
+            print("[!] %d files with exploitation attempts detected in PATH: %s" % (number_of_files_with_detections, path))
             if self.summary:
                 for match in matches:
-                    print('\n  FILE: %s' % match)
                     for line_number in matches[match]:
-                        print('    LINE_NUMBER: %d' % line_number)
+                        print('[!] FILE: %s LINE_NUMBER: %d' % (match, line_number))
         else:
             print("\n[+] No files with exploitation attempts detected in path PATH: %s" % path)
         return number_of_detections
@@ -224,10 +222,9 @@ if __name__ == '__main__':
                 for m in matches_found:
                     matches[f][m['line_number']] = [m['line'], m['match_string']]
                 for match in matches:
-                    print('\nFILE: %s' % match)
                     for line_number in matches[match]:
-                        print('\n  LINE_NUMBER: %s\n    DEOBFUSCATED_STRING: %s' % 
-                            (line_number, matches[match], matches[match][line_number])
+                        print('[!] FILE: %s LINE_NUMBER: %s DEOBFUSCATED_STRING: %s' % 
+                            (match, line_number, matches[match], matches[match][line_number])
                         )
             all_detections = len(matches[f].keys())
     # Scan paths
@@ -246,12 +243,12 @@ if __name__ == '__main__':
 
     # Finish
     if all_detections > 0:
-        print("\n[!!!] %d exploitation attempts detected in the complete scan" % all_detections)
+        print("[!!!] %d exploitation attempts detected in the complete scan" % all_detections)
         
     else:
-        print("\n[.] No exploitation attempts detected in the scan")
+        print("[.] No exploitation attempts detected in the scan")
     date_scan_end = datetime.now()
-    print("\n[.] Finished scan DATE: %s" % date_scan_end)
+    print("[.] Finished scan DATE: %s" % date_scan_end)
     duration = date_scan_end - date_scan_start
     mins, secs = divmod(duration.total_seconds(), 60)
     hours, mins = divmod(mins, 60)


### PR DESCRIPTION
* Changed matches to be in a defaultdict with files and line numbers as keys
*  Added a summary option that only prints files and line numbers
* Simplified Python2 compatibility check, removes need for `sys`
    * Verified works on Python 2.7.16
* Formatted output to be leveled file --> line number --> match
* Simplified argparse requirement for an input