### PR TITLE
regexp pattern to check for log.X.gz

### DIFF
--- a/log4shell-detector.py
+++ b/log4shell-detector.py
@@ -97,7 +97,7 @@ class Log4ShellDetector(object):
         try:
             # Gzipped logs
             suffix = "log\.(\d+\.)?gz";
-            m = re.search(suffix, str)
+            m = re.search(suffix, file_path)
             if m:
                 with gzip.open(file_path, 'rt') as gzlog:        
                     c = 0

--- a/log4shell-detector.py
+++ b/log4shell-detector.py
@@ -8,7 +8,6 @@ import os
 import sys
 import copy
 import gzip
-import re
 py3 = True if sys.version_info > (3, 0) else False
 if py3:
     import urllib.parse
@@ -96,10 +95,8 @@ class Log4ShellDetector(object):
         matches_in_file = []
         try:
             # Gzipped logs
-            suffix = "log\.(\d+\.)?gz";
-            m = re.search(suffix, file_path)
-            if m:
-                with gzip.open(file_path, 'rt') as gzlog:        
+            if "log." in file_path and file_path.endswith(".gz"):
+                with gzip.open(file_path, 'rt') as gzlog:
                     c = 0
                     for line in gzlog: 
                         c += 1

--- a/log4shell-detector.py
+++ b/log4shell-detector.py
@@ -8,6 +8,7 @@ import os
 import sys
 import copy
 import gzip
+import re
 py3 = True if sys.version_info > (3, 0) else False
 if py3:
     import urllib.parse
@@ -95,7 +96,9 @@ class Log4ShellDetector(object):
         matches_in_file = []
         try:
             # Gzipped logs
-            if file_path.endswith(".log.gz"):
+            suffix = "log\.(\d+\.)?gz";
+            m = re.search(suffix, str)
+            if m:
                 with gzip.open(file_path, 'rt') as gzlog:        
                     c = 0
                     for line in gzlog: 


### PR DESCRIPTION
some log fires path have format `log.X.gz` ex:
```
syslog.2.gz
```

not checking  dot in front of  `log` `\.log` as for above example with syslog