### PR TITLE
Fix typo in zstandard message

### DIFF
--- a/log4shell-detector.py
+++ b/log4shell-detector.py
@@ -24,7 +24,7 @@ try:
     import zstandard
     _std_supported = True
 except ImportError:
-    print("[!] No support for zstandared files without 'zstandard' libary")
+    print("[!] No support for zstandard files without 'zstandard' library")
 
 DEFAULT_PATHS = ['/var/log', '/storage/log/vmware', '/var/atlassian/application-data/jira/log']
 


### PR DESCRIPTION
It has an 'e' which should not be in "zstandard" + missing 'r' in
"library"