### PR TITLE
Ansible Playbook Changes

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -3,7 +3,7 @@
   become: true
   gather_facts: no
   vars:
-    log4shell_options: "--silent -p /var/log/"
+    log4shell_options: "-p /var/log/"
   pre_tasks:
     - name: Check Python Version
       ansible.builtin.shell: 'python3 --version'

--- a/playbook.yml
+++ b/playbook.yml
@@ -4,13 +4,23 @@
   gather_facts: no
   vars:
     log4shell_options: "--silent -p /var/log/"
+  pre_tasks:
+    - name: Check Python Version
+      ansible.builtin.shell: 'python3 --version'
+      register: python_version
+      failed_when: "'Python' not in python_version.stdout"
+
+    - name: Verify zstandard Python Library
+      ansible.builtin.shell: 'python3 -c "import zstandard"'
+      register: zstandard_status
+      failed_when: zstandard_status.rc != 0
+
   tasks:
     - name: Check server for log4j IOC
       block:
       - name: Create temporary directory
         ansible.builtin.tempfile:
           state: directory
-        changed_when: false
         register: tempdir
 
       - name: Copy script to server
@@ -18,7 +28,6 @@
           src: "{{ item }}"
           dest: "{{ tempdir.path }}"
           mode: 0700
-        changed_when: false
         loop:
           - log4shell-detector.py
           - Log4ShellDetector
@@ -27,14 +36,17 @@
         ansible.builtin.shell:
           cmd: "{{ tempdir.path }}/log4shell-detector.py {{ log4shell_options }}"
         register: log4shell_result
-        changed_when: false
         async: 0
         poll: 30
         failed_when: "'[!]' in log4shell_result.stdout"
+
       always:
       - name: Cleanup
         ansible.builtin.file:
           path: "{{ tempdir.path }}"
           state: absent
-        changed_when: false
         when: tempdir.path is defined
+
+    - name: log4shell-detector output 
+      debug:
+        msg: "{{ log4shell_result }}"

--- a/playbook.yml
+++ b/playbook.yml
@@ -39,6 +39,8 @@
         async: 0
         poll: 30
         failed_when: "'[!]' in log4shell_result.stdout"
+        notify:
+        - Detector Output
 
       always:
       - name: Cleanup
@@ -47,6 +49,7 @@
           state: absent
         when: tempdir.path is defined
 
-    - name: log4shell-detector output 
+  handlers:
+    - name: Detector Output
       debug:
         msg: "{{ log4shell_result }}"


### PR DESCRIPTION
After aiding an old co-worker to get this running, I noticed some items in the Ansible Playbook that could be modified to help. One thing they noticed was a few of their servers didn't have python3 installed causing the script to never run, however this was only noticed with a `debug` statement. Another item that was run into was the lack of the `zstandard` library not being in a few servers either.

This PR adds checks for that to ensure they exist. Other changes include removing the `changed_when` flag as Ansible users expect when something is actually "done" to be marked as "Changed". The final change is adding debug output for the final `log4shell-detector.py` script that is run. Not entirely required, but for those who may actually want to see the output, this would be helpful (outside of getting a pass/fail). Along with this `--silent` was removed from the `vars` to actually have output to see outside of pass/fail. 